### PR TITLE
Add ability to handle curl errors to the CurlConsumer

### DIFF
--- a/lib/ConsumerStrategies/CurlConsumer.php
+++ b/lib/ConsumerStrategies/CurlConsumer.php
@@ -108,20 +108,20 @@ class ConsumerStrategies_CurlConsumer extends ConsumerStrategies_AbstractConsume
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch,CURLOPT_POSTFIELDS, $data);
         $response = curl_exec($ch);
-	    if (false===$response) {
-		    $curl_error=curl_error($ch);
-		    $curl_errno=curl_errno($ch);
-		    curl_close($ch);
-		    $this->_handleError($curl_errno, $curl_error);
-		    return false;
-	    }
-	    curl_close($ch);
-	    if (trim($response) == "1") {
+        if (false===$response) {
+            $curl_error=curl_error($ch);
+            $curl_errno=curl_errno($ch);
+            curl_close($ch);
+            $this->_handleError($curl_errno, $curl_error);
+            return false;
+        }
+        curl_close($ch);
+        if (trim($response) == "1") {
             return true;
         } else {
             $this->_handleError(0, $response);
-		    return false;
-	    }
+            return false;
+        }
     }
 
 


### PR DESCRIPTION
Add ability to handle curl errors if occurred.
Error code for curl is always non-zero in this situation, so it can be easily distinct from api error.
"if" placement is directed by requirement of non-closed curl handler (to get error) and hypothetical exception throwing from error handler (so curl should be closed before handler call). 
