### PR TITLE
Parallel curl

### DIFF
--- a/lib/ConsumerStrategies/AbstractConsumer.php
+++ b/lib/ConsumerStrategies/AbstractConsumer.php
@@ -49,6 +49,14 @@ abstract class ConsumerStrategies_AbstractConsumer extends Base_MixpanelBase {
     }
 
     /**
+     * Number of requests/batches that will be processed in parallel.
+     * @return int
+     */
+    public function getNumParallelRequests() {
+        return 1;
+    }
+
+    /**
      * Persist a batch of messages in whatever way the implementer sees fit
      * @param array $batch an array of messages to consume
      * @return boolean success or fail

--- a/lib/ConsumerStrategies/AbstractConsumer.php
+++ b/lib/ConsumerStrategies/AbstractConsumer.php
@@ -52,7 +52,7 @@ abstract class ConsumerStrategies_AbstractConsumer extends Base_MixpanelBase {
      * Number of requests/batches that will be processed in parallel.
      * @return int
      */
-    public function getNumParallelRequests() {
+    public function getNumThreads() {
         return 1;
     }
 

--- a/lib/Producers/MixpanelBaseProducer.php
+++ b/lib/Producers/MixpanelBaseProducer.php
@@ -107,12 +107,14 @@ abstract class Producers_MixpanelBaseProducer extends Base_MixpanelBase {
     public function flush($desired_batch_size = 50) {
         $queue_size = count($this->_queue);
         $succeeded = true;
+        $num_threads = $this->_consumer->getNumThreads();
+
         if ($this->_debug()) {
             $this->_log("Flush called - queue size: ".$queue_size);
         }
 
         while($queue_size > 0 && $succeeded) {
-            $batch_size = min(array($queue_size, $desired_batch_size, $this->_options['max_batch_size']));
+            $batch_size = min(array($queue_size, $desired_batch_size*$num_threads, $this->_options['max_batch_size']*$num_threads));
             $batch = array_splice($this->_queue, 0, $batch_size);
             $succeeded = $this->_persist($batch);
 

--- a/test/ConsumerStrategies/CurlConsumerTest.php
+++ b/test/ConsumerStrategies/CurlConsumerTest.php
@@ -67,6 +67,7 @@ class ConsumerStrategies_CurlConsumerTest extends PHPUnit_Framework_TestCase {
             "connect_timeout" => 1,
             "use_ssl"   => true,
             "fork"      => false,
+            "num_threads"      => 5,
             "error_callback"    => 'callback'
         ));
 
@@ -75,6 +76,7 @@ class ConsumerStrategies_CurlConsumerTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($consumer->getTimeout(), 2);
         $this->assertEquals($consumer->getConnectTimeout(), 1);
         $this->assertEquals($consumer->getProtocol(), "https");
+        $this->assertEquals($consumer->getNumThreads(), 5);
     }
 
 }


### PR DESCRIPTION
Implementation of this open issue: https://github.com/mixpanel/mixpanel-php/issues/16

If a new "num_threads" option is passed when using cURL as a consumer strategy, that many parallel cURL requests will be executed in parallel. By default the number of threads used is 1. Example:

``` php
$mp = Mixpanel::getInstance(PROJECT_TOKEN, array('num_threads' => 5));
```

Since this uses curl_multi_exec(), it only works if the cURL process isn't forked ("fork" option is false or not present).

I know "threads" isn't the technically correct term, but I thought "parallel_requests" was a bit too long. Let me know if you want me to change it, though 
