### PR TITLE
Make createAlias adhere to the consumer config

### DIFF
--- a/test/Producers/MixpanelEventsProducerTest.php
+++ b/test/Producers/MixpanelEventsProducerTest.php
@@ -83,4 +83,19 @@ class MixpanelEventsProducerTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($original_id, $msg['properties']['distinct_id']);
         $this->assertEquals($new_id, $msg['properties']['alias']);
     }
+
+    public function testCreateAliasRespectsConsumerSetting() {
+        $tmp_file = __DIR__ . '/test.tmp';
+        $this->assertFileNotExists($tmp_file);
+
+        $options = array('consumer' => 'file', 'file' => $tmp_file);
+        $instance = new Producers_MixpanelEvents('token', $options);
+
+        try {
+            $instance->createAlias(1, 2);
+            $this->assertStringEqualsFile($tmp_file, '[{"event":"$create_alias","properties":{"distinct_id":1,"alias":2,"token":"token"}}]' . PHP_EOL);
+        } finally {
+            unlink($tmp_file);
+        }
+    }
 }

--- a/test/Producers/MixpanelEventsProducerTest.php
+++ b/test/Producers/MixpanelEventsProducerTest.php
@@ -94,8 +94,9 @@ class MixpanelEventsProducerTest extends PHPUnit_Framework_TestCase {
         try {
             $instance->createAlias(1, 2);
             $this->assertStringEqualsFile($tmp_file, '[{"event":"$create_alias","properties":{"distinct_id":1,"alias":2,"token":"token"}}]' . PHP_EOL);
-        } finally {
+        } catch (Exception $e) {
             unlink($tmp_file);
+            throw $e;
         }
     }
 }

--- a/test/Producers/MixpanelEventsProducerTest.php
+++ b/test/Producers/MixpanelEventsProducerTest.php
@@ -98,5 +98,7 @@ class MixpanelEventsProducerTest extends PHPUnit_Framework_TestCase {
             unlink($tmp_file);
             throw $e;
         }
+
+        unlink($tmp_file);
     }
 }


### PR DESCRIPTION
Because at the moment createAlias is unusable for us since we need our own consumer.