### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+dist: trusty
 
 php:
   - 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,18 @@ sudo: false
 dist: trusty
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
   - hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+      sudo: true
 
 install:
   - travis_retry composer self-update


### PR DESCRIPTION
Few reasons:

- `hhvm` isn't supported anymore on `dist: precise`
- `5.3` isn't supported anymore on `dist: trusty`
- `dist: trusty` will become the default somewhere between now and the end of august
- `dist: precise` will require `sudo` somewhere in september

See also: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming