### PR TITLE
Prevent unnecessary call to _encode on non-forked CurlConsumer

### DIFF
--- a/lib/ConsumerStrategies/CurlConsumer.php
+++ b/lib/ConsumerStrategies/CurlConsumer.php
@@ -90,9 +90,9 @@ class ConsumerStrategies_CurlConsumer extends ConsumerStrategies_AbstractConsume
      */
     public function persist($batch) {
         if (count($batch) > 0) {
-            $data = "data=" . $this->_encode($batch);
             $url = $this->_protocol . "://" . $this->_host . $this->_endpoint;
             if ($this->_fork) {
+                $data = "data=" . $this->_encode($batch);
                 return $this->_execute_forked($url, $data);
             } else {
                 return $this->_execute($url, $batch);


### PR DESCRIPTION
`_encode` is being called again on `_execute` function with a batching strategey. Since full-batch encode is not needed for `_execute`, removing it will prevent the code from doing unnecessary encoding. (JSON encoding + Base64)

This tiny MR only moves the initilization of the `$data` to correct place.

Resolves #50 