### PR TITLE
Modify identify to accept $anon_id, and createAlias parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Production Notes
 -------------
 By default, data is sent using ssl over cURL. This works fine when you're tracking a small number of events or aren't concerned with the potentially blocking nature of the PHP cURL calls. However, this isn't very efficient when you're sending hundreds of events (such as in batch processing). Our library comes packaged with an easy way to use a persistent socket connection for much more efficient writes. To enable the persistent socket, simply pass `'consumer' => 'socket'` as an entry in the `$options` array when you instantiate the Mixpanel class. Additionally, you can contribute your own persistence implementation by creating a custom Consumer.
 
+Testing
+-------------
+mixpanel-php uses `phpunit` as the testing framework. Please ensure that `composer` is up to date. 
+To run tests, execute `composer run-script unit-tests` on the root directory. 
+
 Documentation
 -------------
 * <a href="https://mixpanel.com/help/reference/php" target="_blank">Reference Docs</a>

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
         "mixpanel",
         "mixpanel php"
     ],
+    "scripts": {
+        "unit-tests": "phpunit"
+    },
     "homepage": "https://mixpanel.com/help/reference/php",
     "license": "Apache-2.0",
     "authors": [

--- a/docs/classes/Mixpanel.html
+++ b/docs/classes/Mixpanel.html
@@ -706,8 +706,8 @@ the user thread.</p>
             <article class="method">
                 <h3 class="public ">identify()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">identify(string|integer  <span class="argument">$user_id</span>) </pre>
-                <p><em>Identify the user you want to associate to tracked events</em></p>
+                <pre class="signature" style="margin-right: 54px;">identify(string|integer  <span class="argument">$user_id</span>, [optional] string|integer <span class="argument">$anon_id</span>) </pre>
+                <p><em>Identify the user you want to associate to tracked events. The $anon_id must be UUID v4 format and not already merged to an $identified_id. All identify calls with a new and valid $anon_id will trigger a track $identify event, and merge to the $identified_id.</em></p>
                 
 
                                     <h4>Parameters</h4>
@@ -715,6 +715,11 @@ the user thread.</p>
                                                     <tr>
                                 <td>string|integer</td>
                                 <td>$user_id </td>
+                                <td></td>
+                            </tr>
+                                                    <tr>
+                                <td>string|integer</td>
+                                <td>$anon_id </td>
                                 <td></td>
                             </tr>
                                             </table>
@@ -1035,21 +1040,20 @@ instance.</p>
             <article class="method">
                 <h3 class="public ">createAlias()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">createAlias(string|integer  <span class="argument">$original_id</span>, string|integer  <span class="argument">$new_id</span>) </pre>
-                <p><em>Alias an existing id with a different unique id. This is helpful when you want to associate a generated id
-(such as a session id) to a user id or username.</em></p>
+                <pre class="signature" style="margin-right: 54px;">createAlias(string|integer  <span class="argument">$distinct_id</span>, string|integer  <span class="argument">$alias</span>) </pre>
+                <p><em>An alias to be merged with the distinct_id. Each alias can only map to one distinct_id. This is helpful when you want to associate a generated id (such as a session id) to a user id or username.</em></p>
                 
 
                                     <h4>Parameters</h4>
                     <table class="table table-condensed table-hover">
                                                     <tr>
                                 <td>string|integer</td>
-                                <td>$original_id </td>
+                                <td>$distinct_id </td>
                                 <td></td>
                             </tr>
                                                     <tr>
                                 <td>string|integer</td>
-                                <td>$new_id </td>
+                                <td>$alias </td>
                                 <td></td>
                             </tr>
                                             </table>

--- a/docs/classes/Producers_MixpanelEvents.html
+++ b/docs/classes/Producers_MixpanelEvents.html
@@ -1091,8 +1091,8 @@ they will NOT be overwritten.</em></p>
             <article class="method">
                 <h3 class="public ">identify()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">identify(string|integer  <span class="argument">$user_id</span>) </pre>
-                <p><em>Identify the user you want to associate to tracked events</em></p>
+                <pre class="signature" style="margin-right: 54px;">identify(string|integer  <span class="argument">$user_id</span>, [optional] string|integer <span class="argument">$anon_id</span>) </pre>
+                <p><em>Identify the user you want to associate to tracked events. The $anon_id must be UUID v4 format and not already merged to an $identified_id. All identify calls with a new and valid $anon_id will trigger a track $identify event, and merge to the $identified_id.</em></p>
                 
 
                                     <h4>Parameters</h4>
@@ -1100,6 +1100,11 @@ they will NOT be overwritten.</em></p>
                                                     <tr>
                                 <td>string|integer</td>
                                 <td>$user_id </td>
+                                <td></td>
+                            </tr>
+                                                    <tr>
+                                <td>string|integer</td>
+                                <td>$anon_id </td>
                                 <td></td>
                             </tr>
                                             </table>
@@ -1125,9 +1130,8 @@ they will NOT be overwritten.</em></p>
             <article class="method">
                 <h3 class="public ">createAlias()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">createAlias(string|integer  <span class="argument">$original_id</span>, string|integer  <span class="argument">$new_id</span>) : array</pre>
-                <p><em>Alias an existing id with a different unique id. This is helpful when you want to associate a generated id to
-a username or e-mail address.</em></p>
+                <pre class="signature" style="margin-right: 54px;">createAlias(string|integer  <span class="argument">$distinct_id</span>, string|integer  <span class="argument">$alias</span>) : array</pre>
+                <p><em>An alias to be merged with the distinct_id. Each alias can only map to one distinct_id. This is helpful when you want to associate a generated id (such as a session id) to a user id or username.</em></p>
                 <p>Because aliasing can be extremely vulnerable to race conditions and ordering issues, we'll make a synchronous
 call directly to Mixpanel when this method is called. If it fails we'll throw an Exception as subsequent
 events are likely to be incorrectly tracked.</p>
@@ -1136,12 +1140,12 @@ events are likely to be incorrectly tracked.</p>
                     <table class="table table-condensed table-hover">
                                                     <tr>
                                 <td>string|integer</td>
-                                <td>$original_id </td>
+                                <td>$distinct_id </td>
                                 <td></td>
                             </tr>
                                                     <tr>
                                 <td>string|integer</td>
-                                <td>$new_id </td>
+                                <td>$alias </td>
                                 <td></td>
                             </tr>
                                             </table>

--- a/docs/files/Mixpanel.php.txt
+++ b/docs/files/Mixpanel.php.txt
@@ -192,11 +192,13 @@ class Mixpanel extends Base_MixpanelBase {
 
 
     /**
-     * Identify the user you want to associate to tracked events
+     * Identify the user you want to associate to tracked events. The $anon_id must be UUID v4 format and not already merged to an $identified_id.
+     * All identify calls with a new and valid $anon_id will trigger a track $identify event, and merge to the $identified_id.
      * @param string|int $user_id
+     * @param string|int $anon_id
      */
-    public function identify($user_id) {
-        $this->_events->identify($user_id);
+    public function identify($user_id, $anon_id = null) {
+        $this->_events->identify($user_id, $anon_id);
     }
 
     /**
@@ -291,13 +293,13 @@ class Mixpanel extends Base_MixpanelBase {
 
 
     /**
-     * Alias an existing id with a different unique id. This is helpful when you want to associate a generated id
-     * (such as a session id) to a user id or username.
-     * @param string|int $original_id
-     * @param string|int $new_id
+     * An alias to be merged with the distinct_id. Each alias can only map to one distinct_id.
+     * This is helpful when you want to associate a generated id (such as a session id) to a user id or username.
+     * @param string|int $distinct_id
+     * @param string|int $alias
      */
-    public function createAlias($original_id, $new_id) {
-        $this->_events->createAlias($original_id, $new_id);
+    public function createAlias($distinct_id, $alias) {
+        $this->_events->createAlias($distinct_id, $alias);
     }
 }
 

--- a/docs/files/Producers/MixpanelEvents.php.txt
+++ b/docs/files/Producers/MixpanelEvents.php.txt
@@ -116,30 +116,32 @@ class Producers_MixpanelEvents extends Producers_MixpanelBaseProducer {
 
 
     /**
-     * Identify the user you want to associate to tracked events
+     * Identify the user you want to associate to tracked events. The $anon_id must be UUID v4 format and not already merged to an $identified_id.
+     * All identify calls with a new and valid $anon_id will trigger a track $identify event, and merge to the $identified_id.
      * @param string|int $user_id
+     * @param string|int $anon_id
      */
-    public function identify($user_id) {
-        $this->register("distinct_id", $user_id);
+    public function identify($user_id, $anon_id = null) {
+        $this->register("distinct_id", $user_id, $anon_id);
     }
 
 
     /**
-     * Alias an existing id with a different unique id. This is helpful when you want to associate a generated id to
-     * a username or e-mail address.
+     * An alias to be merged with the distinct_id. Each alias can only map to one distinct_id.
+     * This is helpful when you want to associate a generated id (such as a session id) to a user id or username.
      *
      * Because aliasing can be extremely vulnerable to race conditions and ordering issues, we'll make a synchronous
      * call directly to Mixpanel when this method is called. If it fails we'll throw an Exception as subsequent
      * events are likely to be incorrectly tracked.
-     * @param string|int $original_id
-     * @param string|int $new_id
+     * @param string|int $distinct_id
+     * @param string|int $alias
      * @return array $msg
      * @throws Exception
      */
-    public function createAlias($original_id, $new_id) {
+    public function createAlias($distinct_id, $alias) {
         $msg = array(
             "event"         => '$create_alias',
-            "properties"    =>  array("distinct_id" => $original_id, "alias" => $new_id, "token" => $this->_token)
+            "properties"    =>  array("distinct_id" => $distinct_id, "alias" => $alias, "token" => $this->_token)
         );
 
         // Save the current fork/async options
@@ -159,7 +161,7 @@ class Producers_MixpanelEvents extends Producers_MixpanelBaseProducer {
         $this->_options['async'] = $old_async;
 
         if (!$success) {
-            error_log("Creating Mixpanel Alias (original id: $original_id, new id: $new_id) failed");
+            error_log("Creating Mixpanel Alias (distinct id: $distinct_id, alias: $alias) failed");
             throw new Exception("Tried to create an alias but the call was not successful");
         } else {
             return $msg;

--- a/lib/Mixpanel.php
+++ b/lib/Mixpanel.php
@@ -192,11 +192,13 @@ class Mixpanel extends Base_MixpanelBase {
 
 
     /**
-     * Identify the user you want to associate to tracked events
+     * Identify the user you want to associate to tracked events. The $anon_id must be UUID v4 format and not already merged to an $identified_id.
+     * All identify calls with a new and valid $anon_id will trigger a track $identify event, and merge to the $identified_id.
      * @param string|int $user_id
+     * @param string|int $anon_id [optional]
      */
-    public function identify($user_id) {
-        $this->_events->identify($user_id);
+    public function identify($user_id, $anon_id = null) {
+        $this->_events->identify($user_id, $anon_id);
     }
 
     /**
@@ -291,12 +293,12 @@ class Mixpanel extends Base_MixpanelBase {
 
 
     /**
-     * Alias an existing id with a different unique id. This is helpful when you want to associate a generated id
-     * (such as a session id) to a user id or username.
-     * @param string|int $original_id
-     * @param string|int $new_id
+     * An alias to be merged with the distinct_id. Each alias can only map to one distinct_id.
+     * This is helpful when you want to associate a generated id (such as a session id) to a user id or username.
+     * @param string|int $distinct_id
+     * @param string|int $alias
      */
-    public function createAlias($original_id, $new_id) {
-        $this->_events->createAlias($original_id, $new_id);
+    public function createAlias($distinct_id, $alias) {
+        $this->_events->createAlias($distinct_id, $alias);
     }
 }


### PR DESCRIPTION
## Identify & createAlias update
This PR will add a second param to the `identify` method, which will accept an `$anon_id` if present.
This method will now look like this
`public function identify($user_id, $anon_id = null)`
in this function, we do a regex check, and make a `$identify` track call if it's `$anon_id` is present and in UUID v4 format.

We will also modify the `createAlias` method, and change the parameter names from `$original_id` & `$new_id` ---> `$distinct_id` & `$alias`

documentation: https://developer.mixpanel.com/docs/http#section-managing-user-identity