### PR TITLE
PHP 7.4 compatibility

### DIFF
--- a/lib/Base/MixpanelBase.php
+++ b/lib/Base/MixpanelBase.php
@@ -59,7 +59,7 @@ class Base_MixpanelBase {
      * @return bool
      */
     protected function _debug() {
-        return array_key_exists("debug", $this->_options) && $this->_options["debug"] == true;
+        return isset($this->_options["debug"]) && $this->_options["debug"] == true;
     }
 
 }

--- a/lib/ConsumerStrategies/CurlConsumer.php
+++ b/lib/ConsumerStrategies/CurlConsumer.php
@@ -58,11 +58,11 @@ class ConsumerStrategies_CurlConsumer extends ConsumerStrategies_AbstractConsume
 
         $this->_host = $options['host'];
         $this->_endpoint = $options['endpoint'];
-        $this->_connect_timeout = array_key_exists('connect_timeout', $options) ? $options['connect_timeout'] : 5;
-        $this->_timeout = array_key_exists('timeout', $options) ? $options['timeout'] : 30;
-        $this->_protocol = array_key_exists('use_ssl', $options) && $options['use_ssl'] == true ? "https" : "http";
-        $this->_fork = array_key_exists('fork', $options) ? ($options['fork'] == true) : false;
-        $this->_num_threads = array_key_exists('num_threads', $options) ? max(1, intval($options['num_threads'])) : 1;
+        $this->_connect_timeout = isset($options['connect_timeout']) ? $options['connect_timeout'] : 5;
+        $this->_timeout = isset($options['timeout']) ? $options['timeout'] : 30;
+        $this->_protocol = isset($options['use_ssl']) && $options['use_ssl'] == true ? "https" : "http";
+        $this->_fork = isset($options['fork']) ? ($options['fork'] == true) : false;
+        $this->_num_threads = isset($options['num_threads']) ? max(1, intval($options['num_threads'])) : 1;
 
         // ensure the environment is workable for the given settings
         if ($this->_fork == true) {

--- a/lib/ConsumerStrategies/FileConsumer.php
+++ b/lib/ConsumerStrategies/FileConsumer.php
@@ -19,7 +19,7 @@ class ConsumerStrategies_FileConsumer extends ConsumerStrategies_AbstractConsume
         parent::__construct($options);
 
         // what file to write to?
-        $this->_file = array_key_exists("file", $options) ? $options['file'] :  dirname(__FILE__)."/../../messages.txt";
+        $this->_file = isset($options['file']) ? $options['file'] :  dirname(__FILE__)."/../../messages.txt";
     }
 
 

--- a/lib/ConsumerStrategies/SocketConsumer.php
+++ b/lib/ConsumerStrategies/SocketConsumer.php
@@ -83,8 +83,8 @@ class ConsumerStrategies_SocketConsumer extends ConsumerStrategies_AbstractConsu
 
         $this->_host = $options['host'];
         $this->_endpoint = $options['endpoint'];
-        $this->_connect_timeout = array_key_exists('connect_timeout', $options) ? $options['connect_timeout'] : 5;
-        $this->_async = array_key_exists('async', $options) && $options['async'] === false ? false : true;
+        $this->_connect_timeout = isset($options['connect_timeout']) ? $options['connect_timeout'] : 5;
+        $this->_async = isset($options['async']) && $options['async'] === false ? false : true;
 
         if (array_key_exists('use_ssl', $options) && $options['use_ssl'] == true) {
             $this->_protocol = "ssl";
@@ -289,7 +289,7 @@ class ConsumerStrategies_SocketConsumer extends ConsumerStrategies_AbstractConsu
         $body = $lines[count($lines) - 1];
 
         // if the connection has been closed lets kill the socket
-        if (array_key_exists("Connection", $headers) and $headers['Connection'] == "close") {
+        if (isset($headers["Connection"]) and $headers['Connection'] == "close") {
             $this->_destroySocket();
             if ($this->_debug()) {
                 $this->_log("Server told us connection closed so lets destroy the socket so it'll reconnect on next call");

--- a/lib/Producers/MixpanelBaseProducer.php
+++ b/lib/Producers/MixpanelBaseProducer.php
@@ -60,12 +60,12 @@ abstract class Producers_MixpanelBaseProducer extends Base_MixpanelBase {
         parent::__construct($options);
 
         // register any customer consumers
-        if (array_key_exists("consumers", $options)) {
+        if (isset($options["consumers"])) {
             $this->_consumers = array_merge($this->_consumers, $options['consumers']);
         }
 
         // set max queue size
-        if (array_key_exists("max_queue_size", $options)) {
+        if (isset($options["max_queue_size"])) {
             $this->_max_queue_size = $options['max_queue_size'];
         }
 

--- a/lib/Producers/MixpanelEvents.php
+++ b/lib/Producers/MixpanelEvents.php
@@ -23,10 +23,10 @@ class Producers_MixpanelEvents extends Producers_MixpanelBaseProducer {
     public function track($event, $properties = array()) {
 
         // if no token is passed in, use current token
-        if (!array_key_exists("token", $properties)) $properties['token'] = $this->_token;
+        if (!isset($properties["token"])) $properties['token'] = $this->_token;
 
         // if no time is passed in, use the current time
-        if (!array_key_exists('time', $properties)) $properties['time'] = time();
+        if (!isset($properties["time"])) $properties['time'] = time();
 
         $params['event'] = $event;
         $params['properties'] = array_merge($this->_super_properties, $properties);


### PR DESCRIPTION
This small patch replaces array_key_exists calls that have been deprecated in PHP 7.4 with isset calls.