### PR TITLE
Fix PHP 8.1 deprecation warning

### DIFF
--- a/lib/ConsumerStrategies/CurlConsumer.php
+++ b/lib/ConsumerStrategies/CurlConsumer.php
@@ -132,6 +132,8 @@ class ConsumerStrategies_CurlConsumer extends ConsumerStrategies_AbstractConsume
             curl_multi_add_handle($mh,$ch);
         }
 
+        $running = 0;
+
         do {
             curl_multi_exec($mh, $running);
             curl_multi_select($mh);


### PR DESCRIPTION
Fixes a deprecation warning on PHP 8.1:
```
curl_multi_exec(): Passing null to parameter #2 ($still_running) of type int is deprecated
```