### PR TITLE
PHP 8.2 - Dynamic Property Deprecation Warning

### DIFF
--- a/lib/ConsumerStrategies/SocketConsumer.php
+++ b/lib/ConsumerStrategies/SocketConsumer.php
@@ -72,6 +72,11 @@ class ConsumerStrategies_SocketConsumer extends ConsumerStrategies_AbstractConsu
      */
     private $_async;
 
+    /**
+     * @var int the port to use for the socket connection
+     */
+    private $_port;
+
 
     /**
      * Creates a new SocketConsumer and assigns properties from the $options array


### PR DESCRIPTION
Add a fix for the dynamic property deprecation warning 

```
message: Creation of dynamic property ConsumerStrategies_SocketConsumer::$_port is deprecated in /app/vendor/mixpanel/mixpanel-php/lib/ConsumerStrategies/SocketConsumer.php on line 91
```