### PR TITLE
Fix typing of the group property

### DIFF
--- a/lib/Mixpanel.php
+++ b/lib/Mixpanel.php
@@ -125,7 +125,7 @@ class Mixpanel extends Base_MixpanelBase {
 
     /**
      * An instance of the MixpanelGroups class (used to create/update group profiles)
-     * @var Producers_MixpanelPeople
+     * @var Producers_MixpanelGroups
      */
     public $group;
  


### PR DESCRIPTION
The `group` attribute of the `Mixpanel` class was typed as a `MixpanelPeople` class, when indeed it is a `MixpanelGroups` class.

This is my first PR in this project, so I hope this PR meets your requirements. Please let me know if not.