### PR TITLE
Add people and group flush to Mixpanel::flush method.

### DIFF
--- a/lib/Mixpanel.php
+++ b/lib/Mixpanel.php
@@ -128,7 +128,7 @@ class Mixpanel extends Base_MixpanelBase {
      * @var Producers_MixpanelPeople
      */
     public $group;
- 
+
 
 
     /**
@@ -136,7 +136,7 @@ class Mixpanel extends Base_MixpanelBase {
      * @var Mixpanel[]
      */
     private static $_instances = array();
-    
+
 
     /**
      * Instantiates a new Mixpanel instance.
@@ -189,6 +189,8 @@ class Mixpanel extends Base_MixpanelBase {
      */
     public function flush($desired_batch_size = 50) {
         $this->_events->flush($desired_batch_size);
+        $this->people->flush($desired_batch_size);
+        $this->group->flush($desired_batch_size);
     }
 
 


### PR DESCRIPTION
 Most would assume that all three would be flushed if called manually.

The specific use case that led me to this was using Laravel Queues.  We are queueing server side events to send to Mixpanel in the background.  For one reason or another, the flush on destruction is never called automatically when these queued jobs run in the background.  Therefore, we must call "flush" manually.  We couldn't figure out why people properties were not being sent when we flushed until digging in and noticing only events were sent.  