### PR TITLE
Bugfix: Socket Consumer Debug: Prevent PHP Warning: Undefined array key 1

### DIFF
--- a/lib/ConsumerStrategies/SocketConsumer.php
+++ b/lib/ConsumerStrategies/SocketConsumer.php
@@ -288,7 +288,11 @@ class ConsumerStrategies_SocketConsumer extends ConsumerStrategies_AbstractConsu
 
         // extract status
         $line_one_exploded = explode(" ", $lines[0]);
-        $status = $line_one_exploded[1];
+		if ($line_one_exploded === false || ! isset($line_one_exploded[1])) {
+			$status = "Unable to extract HTTP status from response";
+		} else {
+			$status = $line_one_exploded[1];
+		}
 
         // extract body
         $body = $lines[count($lines) - 1];
@@ -301,12 +305,10 @@ class ConsumerStrategies_SocketConsumer extends ConsumerStrategies_AbstractConsu
             }
         }
 
-        $ret = array(
-            "status"  => $status,
-            "body" => $body,
+        return array(
+	        "status" => $status,
+	        "body"   => $body,
         );
-
-        return $ret;
     }
 
 

--- a/lib/ConsumerStrategies/SocketConsumer.php
+++ b/lib/ConsumerStrategies/SocketConsumer.php
@@ -286,8 +286,8 @@ class ConsumerStrategies_SocketConsumer extends ConsumerStrategies_AbstractConsu
 
         }
 
-	    // extract status
-	    $line_one_exploded = explode(" ", $lines[0]);
+		// extract status
+		$line_one_exploded = explode(" ", $lines[0]);
 		if ($line_one_exploded === false || ! isset($line_one_exploded[1])) {
 			$status = "Unable to extract HTTP status from response";
 		} else {

--- a/lib/ConsumerStrategies/SocketConsumer.php
+++ b/lib/ConsumerStrategies/SocketConsumer.php
@@ -286,8 +286,8 @@ class ConsumerStrategies_SocketConsumer extends ConsumerStrategies_AbstractConsu
 
         }
 
-        // extract status
-        $line_one_exploded = explode(" ", $lines[0]);
+	    // extract status
+	    $line_one_exploded = explode(" ", $lines[0]);
 		if ($line_one_exploded === false || ! isset($line_one_exploded[1])) {
 			$status = "Unable to extract HTTP status from response";
 		} else {


### PR DESCRIPTION
This prevents a PHP warning when using the Socket Consumer and have debugging enabled. It seems sometimes the response does not contain an HTTP status and just returns `1` as the body.

### Error Logs
```
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 94 ] : destruct flush attempt #1
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 113 ] : Flush called - queue size: 2
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 146 ] : Creating new socket at 1705518422
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 163 ] : Opening socket connection to ssl://api.mixpanel.com:443
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 218 ] : Socket wrote 922 bytes
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 135 ] : Batch of 2 consumed, queue size is now 0
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 94 ] : destruct flush attempt #1
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 113 ] : Flush called - queue size: 2
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 146 ] : Creating new socket at 1705518422
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 163 ] : Opening socket connection to ssl://api.mixpanel.com:443
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 218 ] : Socket wrote 1538 bytes
appserver_1  | NOTICE: PHP message: PHP Warning:  Undefined array key 1 in /app/vendor/mixpanel/mixpanel-php/lib/ConsumerStrategies/SocketConsumer.php on line 291
```

This is often paired with a PHP Warning of `PHP message: PHP Warning:  fwrite(): SSL: Connection timed out in /app/vendor/mixpanel/mixpanel-php/lib/ConsumerStrategies/SocketConsumer.php on line 215`, but not always. 

```
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 94 ] : destruct flush attempt #1
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 113 ] : Flush called - queue size: 2
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 146 ] : Creating new socket at 1705517840
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 163 ] : Opening socket connection to ssl://api.mixpanel.com:443
appserver_1  | NOTICE: PHP message: PHP Warning:  fwrite(): SSL: Connection timed out in /app/vendor/mixpanel/mixpanel-php/lib/ConsumerStrategies/SocketConsumer.php on line 215
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 218 ] : Socket wrote 0 bytes
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 245 ] : Retrying socket write...
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 146 ] : Creating new socket at 1705517840
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 163 ] : Opening socket connection to ssl://api.mixpanel.com:443
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 218 ] : Socket wrote 922 bytes
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 135 ] : Batch of 2 consumed, queue size is now 0
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 94 ] : destruct flush attempt #1
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 113 ] : Flush called - queue size: 2
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 146 ] : Creating new socket at 1705517840
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 163 ] : Opening socket connection to ssl://api.mixpanel.com:443
appserver_1  | NOTICE: PHP message: [ Base_MixpanelBase - line 218 ] : Socket wrote 1570 bytes
appserver_1  | NOTICE: PHP message: PHP Warning:  Undefined array key 1 in /app/vendor/mixpanel/mixpanel-php/lib/ConsumerStrategies/SocketConsumer.php on line 291
```

**Note:** I'm not sure what the best way is to fix the SSL: Connection timed out warning, but I wanted to note it here.