### PR TITLE
chore: standardize release process

### DIFF
--- a/.github/modules.json
+++ b/.github/modules.json
@@ -1,0 +1,10 @@
+{
+  "analytics": {
+    "tag_prefix": "",
+    "composer_json": "composer.json",
+    "version_files": [],
+    "changelog": "CHANGELOG.md",
+    "readme": "README.md",
+    "package_name": "mixpanel/mixpanel-php"
+  }
+}

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+MODULE="$1"
+VERSION_LABEL="$2"
+REPO_URL="$3"
+END_REF="${4:-HEAD}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULES_JSON="$SCRIPT_DIR/../modules.json"
+
+TAG_PREFIX=$(jq -e -r --arg m "$MODULE" '.[$m].tag_prefix' "$MODULES_JSON") || {
+  echo "Unknown module: $MODULE. Valid modules: $(jq -r 'keys | join(", ")' "$MODULES_JSON")" >&2
+  exit 1
+}
+TAG_GLOB="${TAG_PREFIX}*"
+
+PREVIOUS_TAG=$(git tag --sort=-creatordate --list "$TAG_GLOB" | head -1 || true)
+
+if [ -z "$PREVIOUS_TAG" ]; then
+  RANGE="$END_REF"
+else
+  RANGE="${PREVIOUS_TAG}..${END_REF}"
+fi
+
+DATE=$(date +%Y-%m-%d)
+SAFE_URL=$(printf '%s' "$REPO_URL" | sed 's|[&/\]|\\&|g')
+
+declare -a FEATURES=()
+declare -a FIXES=()
+declare -a CHORES=()
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  MSG=$(echo "$line" | cut -d' ' -f2-)
+
+  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+    TYPE="${BASH_REMATCH[1]}"
+    DESC="${BASH_REMATCH[3]}"
+
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+
+    case "$TYPE" in
+      feat) FEATURES+=("$DESC") ;;
+      fix) FIXES+=("$DESC") ;;
+      chore) CHORES+=("$DESC") ;;
+    esac
+  fi
+done < <(git log --oneline "$RANGE")
+
+echo "## [${VERSION_LABEL}](${REPO_URL}/tree/${VERSION_LABEL}) (${DATE})"
+echo ""
+
+if [ ${#FEATURES[@]} -gt 0 ]; then
+  echo "### Features"
+  for entry in "${FEATURES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#FIXES[@]} -gt 0 ]; then
+  echo "### Fixes"
+  for entry in "${FIXES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#CHORES[@]} -gt 0 ]; then
+  echo "### Chores"
+  for entry in "${CHORES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ -n "$PREVIOUS_TAG" ]; then
+  echo "[Full Changelog](${REPO_URL}/compare/${PREVIOUS_TAG}...${VERSION_LABEL})"
+fi

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -34,17 +34,24 @@ while IFS= read -r line; do
   [ -z "$line" ] && continue
   MSG=$(echo "$line" | cut -d' ' -f2-)
 
-  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+  # feat / fix: include whether bare, scoped to our module, or scoped to
+  # `all` (cross-cutting changes that appear in every module's changelog).
+  # chore: include only when explicitly scoped to our module or `all` —
+  # bare `chore:` is the convention for changes intentionally hidden from
+  # the changelog (release prep PRs, CI tweaks, lockfile bumps, internal
+  # docs).
+  if [[ "$MSG" =~ ^(feat|fix)(\((${MODULE}|all)\))?:\ (.+) ]]; then
     TYPE="${BASH_REMATCH[1]}"
-    DESC="${BASH_REMATCH[3]}"
-
+    DESC="${BASH_REMATCH[4]}"
     DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
-
     case "$TYPE" in
       feat) FEATURES+=("$DESC") ;;
       fix) FIXES+=("$DESC") ;;
-      chore) CHORES+=("$DESC") ;;
     esac
+  elif [[ "$MSG" =~ ^chore\((${MODULE}|all)\):\ (.+) ]]; then
+    DESC="${BASH_REMATCH[2]}"
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+    CHORES+=("$DESC")
   fi
 done < <(git log --oneline "$RANGE")
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -23,8 +23,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
-          # Scope is optional. Bare or scoped to a known module both pass.
-          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          # Scope is optional. Bare, scoped to a known module, or scoped to
+          # `all` (cross-cutting changes that appear in every module's
+          # changelog) all pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST}|all)\))?: .+"
           RELEASE_PATTERN="^release: .+"
 
           if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
@@ -40,10 +42,10 @@ jobs:
           echo "  feat: description"
           echo "  fix: description"
           echo "  chore: description"
-          echo "  feat(<module>): description"
-          echo "  fix(<module>): description"
-          echo "  chore(<module>): description"
+          echo "  feat(<module>|all): description"
+          echo "  fix(<module>|all): description"
+          echo "  chore(<module>|all): description"
           echo "  release: description"
           echo ""
-          echo "Valid modules: ${MODULE_LIST//|/, }"
+          echo "Valid scopes: ${MODULE_LIST//|/, }, all"
           exit 1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,49 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          sparse-checkout: .github/modules.json
+          sparse-checkout-cone-mode: false
+
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
+          # Scope is optional. Bare or scoped to a known module both pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          RELEASE_PATTERN="^release: .+"
+
+          if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
+            echo "PR title is valid: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "PR title does not match the required format."
+          echo ""
+          echo "  Got: $PR_TITLE"
+          echo ""
+          echo "Expected one of:"
+          echo "  feat: description"
+          echo "  fix: description"
+          echo "  chore: description"
+          echo "  feat(<module>): description"
+          echo "  fix(<module>): description"
+          echo "  chore(<module>): description"
+          echo "  release: description"
+          echo ""
+          echo "Valid modules: ${MODULE_LIST//|/, }"
+          exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,188 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to release (must match a key in .github/modules.json)'
+        required: true
+        type: string
+      version:
+        description: 'Release version (e.g., 2.12.0 or 2.12.0-beta.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-${{ inputs.module }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: "Prepare ${{ inputs.module }} ${{ inputs.version }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate inputs
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+          jq -e --arg m "$MODULE" '.[$m]' .github/modules.json > /dev/null || {
+            echo "::error::Unknown module '$MODULE'. Valid modules: $(jq -r 'keys | join(", ")' .github/modules.json)"
+            exit 1
+          }
+
+      - name: Resolve module config
+        id: config
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+
+          # tag_prefix may be empty (e.g. mixpanel-php uses bare semver tags
+          # like `2.11.0`). The concatenation below still yields the bare
+          # version string in that case.
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          {
+            echo "tag=${TAG_PREFIX}${VERSION}"
+            echo "composer_json=$(echo "$MODULE_CONFIG" | jq -r '.composer_json')"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "readme=$(echo "$MODULE_CONFIG" | jq -r '.readme')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+            echo "branch=release/${MODULE}/${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate version not already released
+        env:
+          TAG: ${{ steps.config.outputs.tag }}
+        run: |
+          if git tag -l "$TAG" | grep -q .; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+
+      - name: Clean up existing release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "Closing existing PR #$EXISTING_PR and deleting branch"
+            gh pr close "$EXISTING_PR" --delete-branch
+          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Deleting orphaned branch $BRANCH"
+            git push origin --delete "$BRANCH"
+          fi
+
+      - name: Create release branch
+        env:
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: git checkout -b "$BRANCH"
+
+      # NOTE: composer.json intentionally has NO `version` field. Packagist
+      # reads the version from the git tag itself, and putting an explicit
+      # version in composer.json is actively discouraged because it goes
+      # stale. So the prepare workflow has no "bump composer.json version"
+      # step. The README header + CHANGELOG prepend below are the only file
+      # changes.
+
+      - name: Update README version header
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          TAG: ${{ steps.config.outputs.tag }}
+          README: ${{ steps.config.outputs.readme }}
+        run: |
+          DATE=$(date +"%B %d, %Y")
+          # Replace the version header line.
+          # The `1,/pat/` address range bounds the substitution to lines from
+          # the start of the file through the first match, so a README that
+          # accidentally contains a second matching line is left untouched.
+          sed -i -E \
+            "1,/^##### _.*_ - \[.*\]\(.*\)\$/ s|^##### _.*_ - \[.*\]\(.*\)\$|##### _${DATE}_ - [${TAG}](${REPO_URL}/releases/tag/${TAG})|" \
+            "$README"
+
+      - name: Generate changelog
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          MODULE: ${{ inputs.module }}
+          TAG: ${{ steps.config.outputs.tag }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+        run: |
+          CHANGELOG=$(.github/scripts/generate-changelog.sh \
+            "$MODULE" "$TAG" "$REPO_URL" HEAD)
+
+          if [ -f "$CHANGELOG_FILE" ]; then
+            {
+              printf '# Changelog\n\n%s\n' "$CHANGELOG"
+              sed '1{/^# Changelog$/d;}' "$CHANGELOG_FILE"
+            } > CHANGELOG.new.md
+            mv CHANGELOG.new.md "$CHANGELOG_FILE"
+          else
+            printf '# Changelog\n\n%s\n' "$CHANGELOG" > "$CHANGELOG_FILE"
+          fi
+
+      - name: Commit and push
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CHANGELOG_FILE" "$README"
+          git commit -m "release: prepare ${MODULE} ${VERSION}"
+          git push origin "$BRANCH"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ steps.config.outputs.tag }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          gh pr create \
+            --title "release: prepare ${MODULE} ${VERSION}" \
+            --body "$(cat <<EOF
+          ## Release ${MODULE} ${VERSION}
+
+          This PR prepares the ${MODULE} module for release.
+
+          ### Changes
+          - Updates \`${CHANGELOG_FILE}\` with a new section since the last tag
+          - Updates \`${README}\` version header
+
+          Note: \`composer.json\` is intentionally untouched. Packagist reads the version from the git tag, and there is no \`version\` field in \`composer.json\` to bump.
+
+          ### After merging
+          1. Push tag \`${TAG}\` from the merge commit on \`master\` to trigger the publish workflow:
+             \`\`\`
+             git checkout master && git pull
+             git tag ${TAG}
+             git push origin ${TAG}
+             \`\`\`
+          2. The publish workflow validates the tag and creates a draft GitHub release. Packagist auto-syncs from its GitHub webhook on tag push, so there is no upload step.
+          3. Review the draft GitHub release and click **Publish release** to make it live.
+          EOF
+          )" \
+            --base master \
+            --head "$BRANCH"

--- a/.github/workflows/release-packagist.yml
+++ b/.github/workflows/release-packagist.yml
@@ -124,24 +124,20 @@ jobs:
           TAG: ${{ github.ref_name }}
           CHANGELOG: ${{ steps.module.outputs.changelog }}
         run: |
-          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
-          # Falls back to a placeholder if no matching section is found.
-          python3 - <<'PY' > release_notes.md
-          import os, re, sys
-          tag = os.environ["TAG"]
-          changelog_path = os.environ["CHANGELOG"]
-          try:
-              content = open(changelog_path).read()
-          except FileNotFoundError:
-              print(f"Release {tag}")
-              sys.exit(0)
-          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
-          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
-          if match:
-              print(match.group(1).strip())
-          else:
-              print(f"Release {tag}")
-          PY
+          # Extract this tag's section from CHANGELOG.md via a sed range.
+          # The address `\@^## \[TAG\]@,\@^## \[@` selects from the version
+          # header through the next `## [` line; the inner block deletes
+          # both markers and prints the body. sed range patterns don't test
+          # the end pattern against the start line, so the start doesn't
+          # self-terminate. `\@...@` switches the address delimiter from
+          # `/` to `@` so tags containing `/` (e.g. `openfeature/v0.1.0`)
+          # don't conflict with the default `/`. Mirrors the deployed
+          # mixpanel-android extraction logic. Falls back to a placeholder
+          # if the section is missing or empty.
+          sed -n '\@^## \['"${TAG}"'\]@,\@^## \[@{\@^## \['"${TAG}"'\]@d;\@^## \[@d;p;}' "$CHANGELOG" 2>/dev/null > release_notes.md || true
+          if [ ! -s release_notes.md ]; then
+            echo "Release $TAG" > release_notes.md
+          fi
           echo "--- release_notes.md ---"
           cat release_notes.md
 

--- a/.github/workflows/release-packagist.yml
+++ b/.github/workflows/release-packagist.yml
@@ -1,0 +1,185 @@
+name: Publish Release to Packagist
+
+# Tag-triggered. mixpanel-php uses bare-semver tags (e.g. `2.11.0`,
+# `2.11.0-beta.1`) - the tag IS the version (Packagist reads it directly).
+# The numeric pattern below covers both stable and pre-release tags while
+# avoiding false positives from any non-version refs.
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+concurrency:
+  group: packagist-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create the draft GitHub release
+
+jobs:
+  publish:
+    name: "Publish ${{ github.ref_name }} to Packagist"
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 30
+
+    # Notes on the "publish" step:
+    #   Packagist auto-syncs from a GitHub webhook on tag push. This workflow
+    #   validates the tag, runs the test suite, and creates a draft GitHub
+    #   release. There is NO upload action - the tag push itself (which
+    #   triggered this workflow) is what completes publication once the
+    #   webhook fires. The `release` environment provides the human gate via
+    #   its required-reviewer setting (matching the pattern used by the npm
+    #   and Maven Central ports).
+
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve module from tag
+        id: module
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Find the module whose tag_prefix the tag starts with, preferring
+          # the longest match. The empty-prefix case (mixpanel-php) is handled
+          # naturally - any string startswith("") - and there's only one
+          # module here, so the resolution is trivial. Kept structured this
+          # way for parity with the multi-module ports.
+          # The `.value.tag_prefix as $p | $t | startswith($p)` form binds
+          # the prefix to a variable BEFORE switching context to $t, which
+          # is required because the inner `startswith` call would otherwise
+          # try to read `.value.tag_prefix` against the string $t.
+          MODULE=$(jq -r --arg t "$TAG" '
+            to_entries
+            | map(select(.value.tag_prefix as $p | $t | startswith($p)))
+            | max_by(.value.tag_prefix | length)
+            | .key // empty
+          ' .github/modules.json)
+
+          if [ -z "$MODULE" ]; then
+            echo "::error::Tag '$TAG' does not match any module tag_prefix in .github/modules.json"
+            exit 1
+          fi
+
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          VERSION="${TAG#${TAG_PREFIX}}"
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' (from tag '$TAG') is not a valid semver"
+            exit 1
+          fi
+
+          {
+            echo "module=$MODULE"
+            echo "version=$VERSION"
+            echo "tag_prefix=$TAG_PREFIX"
+            echo "composer_json=$(echo "$MODULE_CONFIG" | jq -r '.composer_json')"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved tag '$TAG' -> module '$MODULE', version '$VERSION'"
+
+      - name: Verify tag commit is on master
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git fetch origin master
+          TAG_SHA=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/master; then
+            echo "::error::Tag '$TAG' ($TAG_SHA) is not an ancestor of origin/master."
+            echo "Tags must be pushed from a commit on the master branch."
+            exit 1
+          fi
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # v2.32.0
+        with:
+          php-version: '7.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Validate composer.json
+        env:
+          COMPOSER_JSON: ${{ steps.module.outputs.composer_json }}
+        run: composer validate --strict --working-dir="$(dirname "$COMPOSER_JSON")"
+
+      - name: Install dependencies (with dev for tests)
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit
+
+      - name: Re-install without dev (production smoke test)
+        run: |
+          rm -rf vendor
+          composer install --no-interaction --no-progress --prefer-dist --no-dev
+
+      - name: Extract changelog section for tag
+        env:
+          TAG: ${{ github.ref_name }}
+          CHANGELOG: ${{ steps.module.outputs.changelog }}
+        run: |
+          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
+          # Falls back to a placeholder if no matching section is found.
+          python3 - <<'PY' > release_notes.md
+          import os, re, sys
+          tag = os.environ["TAG"]
+          changelog_path = os.environ["CHANGELOG"]
+          try:
+              content = open(changelog_path).read()
+          except FileNotFoundError:
+              print(f"Release {tag}")
+              sys.exit(0)
+          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
+          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
+          if match:
+              print(match.group(1).strip())
+          else:
+              print(f"Release {tag}")
+          PY
+          echo "--- release_notes.md ---"
+          cat release_notes.md
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Idempotent: if a draft release for this tag already exists, leave it alone.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release for $TAG already exists; skipping creation"
+          else
+            gh release create "$TAG" \
+              --draft \
+              --title "$TAG" \
+              --notes-file release_notes.md
+          fi
+
+      - name: Summary
+        env:
+          MODULE: ${{ steps.module.outputs.module }}
+          VERSION: ${{ steps.module.outputs.version }}
+          PACKAGE_NAME: ${{ steps.module.outputs.package_name }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## ${MODULE} ${VERSION} ready"
+            echo ""
+            echo "- Tag: \`${TAG}\`"
+            echo "- Package: [${PACKAGE_NAME}](https://packagist.org/packages/${PACKAGE_NAME})"
+            echo "- [Draft GitHub Release](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG})"
+            echo ""
+            echo "### Packagist sync"
+            echo "Packagist auto-syncs from the configured GitHub webhook on tag push."
+            echo "If the new version does not appear within a few minutes, check:"
+            echo "1. The Packagist webhook on this repo's GitHub Settings -> Webhooks page (it should target https://packagist.org/api/github)"
+            echo "2. The package page on Packagist - a manual \"Update\" button is available there"
+            echo ""
+            echo "### Next step"
+            echo "Review the draft GitHub release and click **Publish release** to make it live."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+## [2.11.0](https://github.com/mixpanel/mixpanel-php/tree/2.11.0) (2026-05-13)
+
+- Fix identify regex for $anon_id
+- Fix PHP 8.2 deprecation warning
+
+## [2.10.0](https://github.com/mixpanel/mixpanel-php/tree/2.10.0)
+
+- send millisecond precision timestamps
+
+## [2.9.0](https://github.com/mixpanel/mixpanel-php/tree/2.9.0)
+
+- update regex for $anon_id check
+- Group Analytics Support
+- Fix PHP 8.1 deprecation warning
+- PHP 7.4 compatibility
+
+## [2.8.1](https://github.com/mixpanel/mixpanel-php/tree/2.8.1)
+
+- Updated `$anon_id` regex in `identify` method to support all Mixpanel distinct IDs
+
+## [2.8.0](https://github.com/mixpanel/mixpanel-php/tree/2.8.0)
+
+- Added `$anon_id` parameter to `identify` method, and a track call when parameter exists and is in UUID v4 format
+- Change parameter names for `createAlias` method to `$distinct_id` and `$alias`
+- Prevent unnecessary call to _encode on non-forked CurlConsumer
+- make sure 'Connection' exists before accessing it
+
+## [2.7.0](https://github.com/mixpanel/mixpanel-php/tree/2.7.0)
+
+- Dropped test support for EOL PHP version (all < 7.1)
+- Added [Parallel cURL implementation](https://github.com/mixpanel/mixpanel-php/commit/6f15000309093b54f7f59f07af297f576fd3a498)
+- [Make createAlias adhere to the consumer config](https://github.com/mixpanel/mixpanel-php/commit/1f814c1be704217e4bc8bf570fad844360fa7318)
+- Added [option to set $ignore_alias on people updates](https://github.com/mixpanel/mixpanel-php/commit/f2812f4e696ef747b2ab0640f46df97d1bf309c0)
+- Fixed [Singleton instance must depend on requested token](https://github.com/mixpanel/mixpanel-php/commit/d50267c48b08eb3c5e1dee2b5dd932cf2b4c3977)
+- Fixed license type in composer.json
+- Remove testing on HHVM as its no longer support by composer
+
+## [2.6.2](https://github.com/mixpanel/mixpanel-php/tree/2.6.2)
+
+- Added support for $ignore_time
+- Cleaned up some comments to be more clear
+
+## [2.6.1](https://github.com/mixpanel/mixpanel-php/tree/2.6.1)
+
+- Fixed bug in SocketConsumer timeout
+
+## [2.6](https://github.com/mixpanel/mixpanel-php/tree/2.6)
+
+- Updated default for `connect_timeout` in SocketConsumer to be 5
+
+## [2.5](https://github.com/mixpanel/mixpanel-php/tree/2.5)
+
+- `timeout` option now refers to `CURLOPT_TIMEOUT` instead of `CURLOPT_CONNECTTIMEOUT` in non-forked cURL calls, it has been removed from the SocketConsumer in favor of a new `connect_timeout` option.
+- Added a new `connect_timeout` option for CURLOPT_CONNECTTIMEOUT in non-forked cURL calls (CurlConsumer) and the socket timeout (SocketConsumer)
+- Set default timeout (CURLOPT_TIMEOUT) to 30 seconds in non-forked cURL calls
+- Set default connection timeoute (CURLOPT_CONNECTTIMEOUT) to 5 seconds in non-forked cURL calls
+- We now pass cURL errors from non-forked cURL calls to `_handle_error` with the curl errno and message
+
+## [2.4](https://github.com/mixpanel/mixpanel-php/tree/2.4)
+
+- Fixed a bug where passing the integer 0 for the `ip` parameter would be ignored
+
+## [2.1 - 2.3](https://github.com/mixpanel/mixpanel-php/tree/2.3)
+
+- Broken releases
+
+## [2.0](https://github.com/mixpanel/mixpanel-php/tree/2.0)
+
+- Changed the default consumer to be 'curl' (CurlConsumer)
+- Changed the default setting of 'fork' to false in the Curl Consumer. This means that by default, events and profile updates are sent synchronously using the PHP cURL lib when using the Curl Consumer.
+- 'createAlias' uses the CurlConsumer with 'fork' explicitly set to false (as we need this to be synchronous) instead of the SocketConsumer.
+- Fixed bug where max_queue_size was never read

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Mixpanel PHP Library [![Build Status](https://travis-ci.org/mixpanel/mixpanel-php.svg)](https://travis-ci.org/mixpanel/mixpanel-php)
 ============
+
+##### _May 13, 2026_ - [2.11.0](https://github.com/mixpanel/mixpanel-php/releases/tag/2.11.0)
+
 This library provides an API to track events and update profiles on Mixpanel.
 
 Install with Composer


### PR DESCRIPTION
## Summary

Standardizes this repo's release process to match the rest of the Mixpanel SDK fleet, per the [SDK Release Process Standardization Effort](https://www.notion.so/mxpnl/SDK-Release-Process-Standardization-Effort-348e0ba925628029af63c779caa835f9).

After merge, releases follow a uniform two-step ceremony:

1. Run the **Prepare Release** workflow (`prepare-release.yml`) — opens a release PR with the version bump, changelog section, and README header line updated.
2. Push the release tag — `release-packagist.yml` validates, gates on the `release` GitHub environment for human approval, and publishes (where applicable for this ecosystem).

## What's added

- `.github/modules.json` — single source of truth for module config (paths, tag prefixes, package names)
- `.github/workflows/prepare-release.yml` — manual dispatch, opens release PR
- `.github/workflows/release-packagist.yml` — tag-triggered publish workflow
- `.github/workflows/pr-title-check.yml` — conventional-commit enforcement (regex built from `modules.json`)
- `.github/scripts/generate-changelog.sh` — shared changelog generator (verbatim from mixpanel-android)
- README version-header line on each module's README, seeded with the current latest tag
- `CHANGELOG.md` per module where missing
- Single module `analytics` (`mixpanel/mixpanel-php` on Packagist)
- Tag style preserved as **bare semver** (`2.12.0`, not `v2.12.0`) — Packagist resolves both styles, but switching would break Composer constraint resolution for downstream consumers
- composer.json has no `version` field — Packagist reads from the git tag. The publish workflow has no upload step; Packagist auto-syncs via the existing GitHub webhook
- New `CHANGELOG.md` seeded from the existing changelog history embedded in the README

## How releases work after this lands

Full ceremony, one-time setup, and PR title conventions: **[PHP Release Runbook](https://www.notion.so/mxpnl/PHP-Release-Runbook-35ee0ba925628023b0d4f002fe5c004a)**

## One-time setup before the first release

The runbook lists the full setup. The work that requires repo-admin access (cannot be done in this PR):

- Create a GitHub Environment named `release` with required reviewer(s)
- Branch protection on the default branch (require PR review + the new `Validate PR title` check)
- Tag rulesets (restrict creation/update/deletion of release tags)
- Workflow permissions: enable `Read and write permissions` and `Allow GitHub Actions to create and approve pull requests` (needed by `prepare-release.yml`'s `gh pr create`)

## Notes

- This is a **WIP** draft to be reviewed alongside the equivalent PRs in the other SDK repos. The Flutter and React Native ports are tracked at mixpanel-flutter#238, mixpanel-flutter-session-replay#30, mixpanel-react-native#408, mixpanel-react-native-session-replay#64.
- This PR does not change any source code or build behavior — only adds release infrastructure.
- The standardization commit is followed by a small `fix:` commit correcting a jq tag-resolution snippet (the same bug exists in the WIP Flutter/RN PRs and should be back-ported there).