### PR TITLE
fix(analytics): add escapeshellarg() hardening in CurlConsumer::_execute_forked()

### DIFF
--- a/lib/ConsumerStrategies/CurlConsumer.php
+++ b/lib/ConsumerStrategies/CurlConsumer.php
@@ -177,7 +177,7 @@ class ConsumerStrategies_CurlConsumer extends ConsumerStrategies_AbstractConsume
             $this->_log("Making forked cURL call to $url");
         }
 
-        $exec = 'curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d ' . escapeshellarg($data) . ' ' . escapeshellarg($url);
+        $exec = $this->_buildExecCommand($url, $data);
 
         if(!$this->_debug()) {
             $exec .= " >/dev/null 2>&1 &";
@@ -190,6 +190,19 @@ class ConsumerStrategies_CurlConsumer extends ConsumerStrategies_AbstractConsume
         }
 
         return $return_var == 0;
+    }
+
+
+    /**
+     * Build the shell command used by the forked cURL call. The $url and $data
+     * values are passed through escapeshellarg() to prevent shell injection.
+     * @param $url
+     * @param $data
+     * @return string
+     */
+    protected function _buildExecCommand($url, $data) {
+        return 'curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d '
+            . escapeshellarg($data) . ' ' . escapeshellarg($url);
     }
 
     /**

--- a/lib/ConsumerStrategies/CurlConsumer.php
+++ b/lib/ConsumerStrategies/CurlConsumer.php
@@ -177,7 +177,7 @@ class ConsumerStrategies_CurlConsumer extends ConsumerStrategies_AbstractConsume
             $this->_log("Making forked cURL call to $url");
         }
 
-        $exec = 'curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d ' . $data . ' "' . $url . '"';
+        $exec = 'curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d ' . escapeshellarg($data) . ' ' . escapeshellarg($url);
 
         if(!$this->_debug()) {
             $exec .= " >/dev/null 2>&1 &";

--- a/test/ConsumerStrategies/CurlConsumerTest.php
+++ b/test/ConsumerStrategies/CurlConsumerTest.php
@@ -57,6 +57,31 @@ class ConsumerStrategies_CurlConsumerTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($error_handler->last_code, CURLE_COULDNT_RESOLVE_HOST);
     }
 
+    public function testForkedCommandEscapesShellInjection() {
+        $consumer = new CurlConsumer(array(
+            "host"      => "localhost",
+            "endpoint"  => "/endpoint",
+            "use_ssl"   => false,
+            "fork"      => true
+        ));
+
+        // Payloads that would break out of the shell command if left unescaped.
+        $url  = 'http://localhost/endpoint"; touch /tmp/pwned; echo "';
+        $data = 'data=foo`whoami`$(id)';
+
+        $cmd = $consumer->buildExecCommand($url, $data);
+
+        // Both arguments must be passed through escapeshellarg(), so the only
+        // occurrence of each value in the command is the safely-quoted one.
+        $expected = 'curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d '
+            . escapeshellarg($data) . ' ' . escapeshellarg($url);
+        $this->assertEquals($expected, $cmd);
+
+        // The dangerous metacharacters must live inside single quotes, never bare.
+        $this->assertNotContains('"; touch', str_replace(escapeshellarg($url), '', $cmd));
+        $this->assertNotContains('`whoami`', str_replace(escapeshellarg($data), '', $cmd));
+    }
+
     public function testOptions() {
         function callback() { }
 
@@ -146,6 +171,12 @@ class CurlConsumer extends ConsumerStrategies_CurlConsumer {
     {
         $this->forkedCalls++;
         return parent::_execute_forked($url, $data);
+    }
+
+    // Public seam exposing the protected command builder for testing.
+    public function buildExecCommand($url, $data)
+    {
+        return $this->_buildExecCommand($url, $data);
     }
 
 }


### PR DESCRIPTION
## Summary

In `lib/ConsumerStrategies/CurlConsumer.php`, `_execute_forked()` built its shell command via raw string concatenation, passing `$url` and `$data` to `exec()` without shell escaping.

This wraps both with `escapeshellarg()`, removing the shell-injection sharp edge entirely. The trailing `>/dev/null 2>&1 &` is appended outside the escaped args, so backgrounding behavior is unchanged.

## Fix

```php
$exec = 'curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d '
    . escapeshellarg($data) . ' ' . escapeshellarg($url);
```

Exploitation requires a consuming app to feed attacker-controlled input into SDK config/payload (not a typical usage pattern), so severity is low — but the escaping is zero-cost hardening. This is the only shell-execution surface in the SDK.

## References

- SDK-98
- HackerOne #3406746 (closed N/A — no real-world exploit path, but hardening warranted)